### PR TITLE
Footer hidden on mobile

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -314,6 +314,7 @@ section {
 @media (max-width: 991px) {
     .main-content {
         padding-top: 50px;
+	padding-bottom: 100px;
     }
 }
 


### PR DESCRIPTION
Bug fix.

On mobile, few pixels are hidden on bottom of the screen. 

Setting 100px as padding-bottom of .main-content on mobile resolve this issue.

Thank you for the theme, is really great!