### PR TITLE
Applying animsition on header and aside elements

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1255,12 +1255,13 @@
 (function ($) {
     // USE STRICT
     "use strict";
+     var hrefSelector = 'a:not([target="_blank"]):not([href^="#"]):not([class^="chosen-single"])';
     $(".animsition").animsition({
       inClass: 'fade-in',
       outClass: 'fade-out',
       inDuration: 900,
       outDuration: 900,
-      linkElement: 'a:not([target="_blank"]):not([href^="#"]):not([class^="chosen-single"])',
+      linkElement: '.menu-sidebar ' + hrefSelector + ', .menu-sidebar2 ' + hrefSelector + ', .menu-sidebar3 ' + hrefSelector + ', .header-desktop3 ' + hrefSelector,
       loading: true,
       loadingParentElement: 'html',
       loadingClass: 'page-loader',

--- a/js/main.js
+++ b/js/main.js
@@ -1255,13 +1255,15 @@
 (function ($) {
     // USE STRICT
     "use strict";
-     var hrefSelector = 'a:not([target="_blank"]):not([href^="#"]):not([class^="chosen-single"])';
+    var navbars = ['header', 'aside'];
+    var hrefSelector = 'a:not([target="_blank"]):not([href^="#"]):not([class^="chosen-single"])';
+    var linkElement = navbars.map(element => element + ' ' + hrefSelector).join(', ');
     $(".animsition").animsition({
       inClass: 'fade-in',
       outClass: 'fade-out',
       inDuration: 900,
       outDuration: 900,
-      linkElement: '.menu-sidebar ' + hrefSelector + ', .menu-sidebar2 ' + hrefSelector + ', .menu-sidebar3 ' + hrefSelector + ', .header-desktop3 ' + hrefSelector,
+      linkElement: linkElement,
       loading: true,
       loadingParentElement: 'html',
       loadingClass: 'page-loader',


### PR DESCRIPTION
This pull request references to this bug: https://github.com/puikinsh/CoolAdmin/issues/6

With this pull request the plugin animsition will only be applied on the header and aside tags, because otherwise it may interfere with some other plugins, which causes an `/undefined` redirect and a blank page, as described in the bug.